### PR TITLE
Add necessary travis files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - jruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+task :default => :spec


### PR DESCRIPTION
By default, Travis just runs 'rake'. So setup travis to run the build on 1.8, 1.9 and jruby-head (just for fun).
